### PR TITLE
210504_add_and_start_task_api

### DIFF
--- a/xxl-job-admin/Dockerfile
+++ b/xxl-job-admin/Dockerfile
@@ -10,4 +10,6 @@ ENV PARAMS=""
 
 ADD target/xxl-job-admin-*.jar /app.jar
 
+EXPOSE 8080
+
 ENTRYPOINT ["sh","-c","java -jar $JAVA_OPTS /app.jar $PARAMS"]

--- a/xxl-job-admin/Dockerfile
+++ b/xxl-job-admin/Dockerfile
@@ -3,8 +3,10 @@ MAINTAINER xuxueli
 
 ENV PARAMS=""
 
-ENV TZ=PRC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+#ENV TZ=PRC
+#RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+#ENV JAVA_OPTS="-Xms1024m -Xmx3072m"
 
 ADD target/xxl-job-admin-*.jar /app.jar
 

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobInfoController.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/controller/JobInfoController.java
@@ -1,6 +1,6 @@
 package com.xxl.job.admin.controller;
 
-import com.xxl.job.admin.core.cron.CronExpression;
+import com.xxl.job.admin.controller.annotation.PermissionLimit;
 import com.xxl.job.admin.core.exception.XxlJobException;
 import com.xxl.job.admin.core.model.XxlJobGroup;
 import com.xxl.job.admin.core.model.XxlJobInfo;
@@ -21,6 +21,7 @@ import com.xxl.job.core.glue.GlueTypeEnum;
 import com.xxl.job.core.util.DateUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,7 +30,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
-import java.text.ParseException;
 import java.util.*;
 
 /**
@@ -45,6 +45,12 @@ public class JobInfoController {
 	private XxlJobGroupDao xxlJobGroupDao;
 	@Resource
 	private XxlJobService xxlJobService;
+
+	@Value("${emaily.access_token.key}")
+	private String emailyAccessTokenKey;
+
+	@Value("${emaily.access_token.value}")
+	private String emailyAccessTokenValue;
 	
 	@RequestMapping
 	public String index(HttpServletRequest request, Model model, @RequestParam(required = false, defaultValue = "-1") int jobGroup) {
@@ -176,5 +182,15 @@ public class JobInfoController {
 		return new ReturnT<List<String>>(result);
 
 	}
-	
+
+	@RequestMapping("/add-and-start")
+	@ResponseBody
+	@PermissionLimit(limit = false)
+	public ReturnT<String> addAndStart(HttpServletRequest request, XxlJobInfo jobInfo) {
+		if (!request.getHeader(emailyAccessTokenKey).equals(emailyAccessTokenValue)) {
+			logger.error("[XXL-JOB-ADMIN: addAndStart @-1] Emaily access token is wrong!");
+			return new ReturnT<String>(ReturnT.FAIL_CODE, "Emaily access token is wrong!");
+		}
+		return xxlJobService.addAndStart(jobInfo);
+	}
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/XxlJobService.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/XxlJobService.java
@@ -83,4 +83,12 @@ public interface XxlJobService {
 	 */
 	public ReturnT<Map<String,Object>> chartInfo(Date startDate, Date endDate);
 
+	/**
+	 * add and start job
+	 *
+	 * @param jobInfo
+	 * @return
+	 */
+	public ReturnT<String> addAndStart(XxlJobInfo jobInfo);
+
 }

--- a/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
+++ b/xxl-job-admin/src/main/java/com/xxl/job/admin/service/impl/XxlJobServiceImpl.java
@@ -431,4 +431,13 @@ public class XxlJobServiceImpl implements XxlJobService {
 		return new ReturnT<Map<String, Object>>(result);
 	}
 
+	@Override
+	public ReturnT<String> addAndStart(XxlJobInfo jobInfo) {
+		ReturnT<String> add = this.add(jobInfo);
+		if (add.getCode() == ReturnT.FAIL_CODE){
+			return add;
+		}
+		ReturnT<String> start = this.start(Integer.parseInt(add.getContent()));
+		return start;
+	}
 }

--- a/xxl-job-admin/src/main/resources/application.properties
+++ b/xxl-job-admin/src/main/resources/application.properties
@@ -23,9 +23,9 @@ mybatis.mapper-locations=classpath:/mybatis-mapper/*Mapper.xml
 #mybatis.type-aliases-package=com.xxl.job.admin.core.model
 
 ### xxl-job, datasource
-spring.datasource.url=jdbc:mysql://127.0.0.1:3306/xxl_job?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&serverTimezone=Asia/Shanghai
-spring.datasource.username=root
-spring.datasource.password=root_pwd
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 ### datasource-pool
@@ -52,7 +52,7 @@ spring.mail.properties.mail.smtp.starttls.required=true
 spring.mail.properties.mail.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory
 
 ### xxl-job, access token
-xxl.job.accessToken=
+xxl.job.accessToken=${SCHEDULER_ACCESS_TOKEN:}
 
 ### xxl-job, i18n (default is zh_CN, and you can choose "zh_CN", "zh_TC" and "en")
 xxl.job.i18n=zh_CN
@@ -63,3 +63,7 @@ xxl.job.triggerpool.slow.max=100
 
 ### xxl-job, log retention days
 xxl.job.logretentiondays=30
+
+# access token from emaily
+emaily.access_token.key=${EMAILY_ACCESS_TOKEN_KEY}
+emaily.access_token.value=${EMAILY_ACCESS_TOKEN_VALUE}

--- a/xxl-job-admin/src/main/resources/static/js/jobgroup.index.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/jobgroup.index.1.js
@@ -203,7 +203,7 @@ $(function() {
 			},
 			title : {
 				required : true,
-				rangelength:[4, 12]
+				rangelength:[4, 50]
 			}
 		},
 		messages : {
@@ -300,7 +300,7 @@ $(function() {
 			},
 			title : {
 				required : true,
-				rangelength:[4, 12]
+				rangelength:[4, 50]
 			}
 		},
 		messages : {

--- a/xxl-job-admin/src/main/resources/static/js/joblog.index.1.js
+++ b/xxl-job-admin/src/main/resources/static/js/joblog.index.1.js
@@ -82,7 +82,11 @@ $(function() {
 	        	obj.jobGroup = $('#jobGroup').val();
 	        	obj.jobId = $('#jobId').val();
                 obj.logStatus = $('#logStatus').val();
-				obj.filterTime = $('#filterTime').val();
+				var timeRange = $('#filterTime').val().split(" - ");
+				var fromTime = new Date(timeRange[0]).toISOString().substr(0, 19).replace("T", " ");
+				var toTime = new Date(timeRange[1]).toISOString().substr(0, 19).replace("T", " ");
+				obj.filterTime = fromTime + ' - ' + toTime;
+				//obj.filterTime = $('#filterTime').val();
 	        	obj.start = d.start;
 	        	obj.length = d.length;
                 return obj;

--- a/xxl-job-admin/src/main/resources/templates/jobgroup/jobgroup.index.ftl
+++ b/xxl-job-admin/src/main/resources/templates/jobgroup/jobgroup.index.ftl
@@ -85,7 +85,7 @@
                         </div>
                         <div class="form-group">
                             <label for="lastname" class="col-sm-2 control-label">${I18n.jobgroup_field_title}<font color="red">*</font></label>
-                            <div class="col-sm-10"><input type="text" class="form-control" name="title" placeholder="${I18n.system_please_input}${I18n.jobgroup_field_title}" maxlength="12" ></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" name="title" placeholder="${I18n.system_please_input}${I18n.jobgroup_field_title}" maxlength="50" ></div>
                         </div>
                         <div class="form-group">
                             <label for="lastname" class="col-sm-2 control-label">${I18n.jobgroup_field_addressType}<font color="red">*</font></label>
@@ -129,7 +129,7 @@
                         </div>
                         <div class="form-group">
                             <label for="lastname" class="col-sm-2 control-label">${I18n.jobgroup_field_title}<font color="red">*</font></label>
-                            <div class="col-sm-10"><input type="text" class="form-control" name="title" placeholder="${I18n.system_please_input}${I18n.jobgroup_field_title}" maxlength="12" ></div>
+                            <div class="col-sm-10"><input type="text" class="form-control" name="title" placeholder="${I18n.system_please_input}${I18n.jobgroup_field_title}" maxlength="50" ></div>
                         </div>
                         <div class="form-group">
                             <label for="lastname" class="col-sm-2 control-label">${I18n.jobgroup_field_addressType}<font color="red">*</font></label>


### PR DESCRIPTION
1. 新增创建并启动定时任务的api
2. 修改调度日志显示页面的日期区间的搜索条件，向后端传递日期时将时间先转为UTC再传输
3. 创建执行器时，将title的长度由12改为50（需同步修改数据库字段长度）